### PR TITLE
add arm support to images via buildx in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ SPLUNK_LINUX_FILENAME ?= splunk-${SPLUNK_VERSION}-${SPLUNK_BUILD}-Linux-${SPLUNK
 SPLUNK_LINUX_BUILD_URL ?= https://download.splunk.com/products/${SPLUNK_PRODUCT}/releases/${SPLUNK_VERSION}/linux/${SPLUNK_LINUX_FILENAME}
 UF_LINUX_FILENAME ?= splunkforwarder-${SPLUNK_VERSION}-${SPLUNK_BUILD}-Linux-
 UF_LINUX_BUILD_URL ?= https://download.splunk.com/products/universalforwarder/releases/${SPLUNK_VERSION}/linux/${UF_LINUX_FILENAME}
+UF_LINUX_TARGET_PLATFORMS ?= linux/amd64,linux/arm64
 # Windows Splunk arguments
 SPLUNK_WIN_FILENAME ?= splunk-${SPLUNK_VERSION}-${SPLUNK_BUILD}-x64-release.msi
 SPLUNK_WIN_BUILD_URL ?= https://download.splunk.com/products/${SPLUNK_PRODUCT}/releases/${SPLUNK_VERSION}/windows/${SPLUNK_WIN_FILENAME}
@@ -73,7 +74,8 @@ base-centos-8:
 	docker build ${DOCKER_BUILD_FLAGS} --build-arg SCLOUD_URL=${SCLOUD_URL} -t base-centos-8:${IMAGE_VERSION} ./base/centos-8
 
 base-redhat-8:
-	docker build ${DOCKER_BUILD_FLAGS} --build-arg SCLOUD_URL=${SCLOUD_URL} --label version=${SPLUNK_VERSION} -t base-redhat-8:${IMAGE_VERSION} ./base/redhat-8
+	docker buildx build ${DOCKER_BUILD_FLAGS} --platform ${UF_LINUX_TARGET_PLATFORMS} --build-arg SCLOUD_URL=${SCLOUD_URL} \
+		--label version=${SPLUNK_VERSION} -t base-redhat-8:${IMAGE_VERSION} ./base/redhat-8
 
 base-windows-2016:
 	docker build ${DOCKER_BUILD_FLAGS} -t base-windows-2016:${IMAGE_VERSION} ./base/windows-2016
@@ -110,7 +112,8 @@ minimal-centos-8: base-centos-8
 		--target minimal -t minimal-centos-8:${IMAGE_VERSION} .
 
 minimal-redhat-8: base-redhat-8
-	docker build ${DOCKER_BUILD_FLAGS} \
+	docker buildx build ${DOCKER_BUILD_FLAGS} \
+		--platform ${UF_LINUX_TARGET_PLATFORMS} \
 		-f splunk/common-files/Dockerfile \
 		--build-arg SPLUNK_BASE_IMAGE=base-redhat-8 \
 		--build-arg SPLUNK_BUILD_URL=${SPLUNK_LINUX_BUILD_URL} \
@@ -148,7 +151,8 @@ bare-centos-8: base-centos-8
 		--target bare -t bare-centos-8:${IMAGE_VERSION} .	
 
 bare-redhat-8: base-redhat-8
-	docker build ${DOCKER_BUILD_FLAGS} \
+	docker buildx build ${DOCKER_BUILD_FLAGS} \
+		--platform ${UF_LINUX_TARGET_PLATFORMS} \
 		-f splunk/common-files/Dockerfile \
 		--build-arg SPLUNK_BASE_IMAGE=base-redhat-8 \
 		--build-arg SPLUNK_BUILD_URL=${SPLUNK_LINUX_BUILD_URL} \
@@ -245,7 +249,8 @@ uf-centos-8: base-centos-8 ansible
 		-t uf-centos-8:${IMAGE_VERSION} .
 
 uf-redhat-8: base-redhat-8 ansible
-	docker build ${DOCKER_BUILD_FLAGS} \
+	docker buildx build ${DOCKER_BUILD_FLAGS} \
+		--platform ${UF_LINUX_TARGET_PLATFORMS} \
 		-f uf/common-files/Dockerfile \
 		--build-arg SPLUNK_BASE_IMAGE=base-redhat-8 \
 		--build-arg SPLUNK_BUILD_URL=${UF_LINUX_BUILD_URL} \
@@ -319,7 +324,8 @@ uf-py23-centos-8: uf-centos-8
 		-t uf-py23-centos-8:${IMAGE_VERSION} .
 
 uf-py23-redhat-8: uf-redhat-8
-	docker build ${DOCKER_BUILD_FLAGS} \
+	docker buildx build ${DOCKER_BUILD_FLAGS} \
+		--platform ${UF_LINUX_TARGET_PLATFORMS} \
 		-f py23-image/redhat-8/Dockerfile \
 		--build-arg SPLUNK_PRODUCT=uf \
 		-t uf-py23-redhat-8:${IMAGE_VERSION} .

--- a/base/centos-8/install.sh
+++ b/base/centos-8/install.sh
@@ -23,8 +23,15 @@ export LANG=en_US.utf8
 yum -y update && yum -y install wget sudo epel-release make
 yum -y install ansible python3-requests python3-jmespath
 
+# map os arch to busybox arch labels as needed
+ARCH=`arch`
+if [[ $ARCH = aarch64 ]]
+then
+  ARCH="armv8l"
+fi
+
 # Install busybox
-wget -O /bin/busybox https://busybox.net/downloads/binaries/1.28.1-defconfig-multiarch/busybox-`arch`
+wget -O /bin/busybox https://busybox.net/downloads/binaries/1.28.1-defconfig-multiarch/busybox-${ARCH}
 chmod +x /bin/busybox
 
 # Install scloud

--- a/base/centos-8/install.sh
+++ b/base/centos-8/install.sh
@@ -23,17 +23,6 @@ export LANG=en_US.utf8
 yum -y update && yum -y install wget sudo epel-release make
 yum -y install ansible python3-requests python3-jmespath
 
-# map os arch to busybox arch labels as needed
-ARCH=`arch`
-if [[ $ARCH = aarch64 ]]
-then
-  ARCH="armv8l"
-fi
-
-# Install busybox
-wget -O /bin/busybox https://busybox.net/downloads/binaries/1.28.1-defconfig-multiarch/busybox-${ARCH}
-chmod +x /bin/busybox
-
 # Install scloud
 wget -O /usr/bin/scloud.tar.gz ${SCLOUD_URL}
 tar -xf /usr/bin/scloud.tar.gz -C /usr/bin/

--- a/base/redhat-8/install.sh
+++ b/base/redhat-8/install.sh
@@ -77,8 +77,15 @@ wget -O /usr/bin/scloud.tar.gz ${SCLOUD_URL}
 tar -xf /usr/bin/scloud.tar.gz -C /usr/bin/
 rm /usr/bin/scloud.tar.gz
 
+# map os arch to busybox arch labels as needed
+ARCH=`arch`
+if [[ $ARCH = aarch64 ]]
+then
+  ARCH="armv8l"
+fi
+
 # Install busybox direct from the multiarch since EPEL isn't available yet for redhat8
-wget -O /bin/busybox https://busybox.net/downloads/binaries/1.28.1-defconfig-multiarch/busybox-`arch`
+wget -O /bin/busybox https://busybox.net/downloads/binaries/1.28.1-defconfig-multiarch/busybox-${ARCH}
 chmod +x /bin/busybox
 
 # Enable busybox symlinks

--- a/base/redhat-8/install.sh
+++ b/base/redhat-8/install.sh
@@ -77,24 +77,6 @@ wget -O /usr/bin/scloud.tar.gz ${SCLOUD_URL}
 tar -xf /usr/bin/scloud.tar.gz -C /usr/bin/
 rm /usr/bin/scloud.tar.gz
 
-# map os arch to busybox arch labels as needed
-ARCH=`arch`
-if [[ $ARCH = aarch64 ]]
-then
-  ARCH="armv8l"
-fi
-
-# Install busybox direct from the multiarch since EPEL isn't available yet for redhat8
-wget -O /bin/busybox https://busybox.net/downloads/binaries/1.28.1-defconfig-multiarch/busybox-${ARCH}
-chmod +x /bin/busybox
-
-# Enable busybox symlinks
-cd /bin
-BBOX_LINKS=( clear find diff hostname killall netstat nslookup ping ping6 readline route syslogd tail traceroute vi )
-for item in "${BBOX_LINKS[@]}"
-do
-  ln -s busybox $item || true
-done
 chmod u+s /bin/ping
 groupadd sudo
 

--- a/uf/common-files/install.sh
+++ b/uf/common-files/install.sh
@@ -20,6 +20,9 @@ SPLUNK_ARCH=`arch`
 if [[ $SPLUNK_ARCH = `s390x` ]]
 then
   SPLUNK_ARCH="s390x"
+elif [[ $SPLUNK_ARCH = `aarch64` ]]
+then
+  SPLUNK_ARCH="armv8"
 else
   SPLUNK_ARCH="x86_64"
 fi


### PR DESCRIPTION
**Problem**

Splunk has made the universal forwarder binaries for ARM processor achitectures/graviton2, but the docker-splunk repo has not yet been updated to produce the images.  

**Solution**

Updates the `Makefile` to use buildx and introduces a `UF_LINUX_TARGET_PLATFORMS` environment variable so that local development can create ARM images for local development, push to ECR or other registries.

Some aspects of this PR is made obsolete by work done in the upstream repo to replace circleci with github actions to build the containers (https://github.com/splunk/docker-splunk/pull/509).  As part of this work, modern github actions are used and the buildx plugin is used to create ARM compatible multi-arch containers.   Once this PR is merged upstream, I will take the changes into this repo.   Still having the Makefile updates and new environment variable are useful for local development/messing around, creating one-off splunk forwarder builds and could be used if GHA are not an option.